### PR TITLE
Include external dset library from mapmap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ include_directories(SYSTEM
     ${CMAKE_SOURCE_DIR}/elibs/eigen
     ${CMAKE_SOURCE_DIR}/elibs/mapmap/
     ${CMAKE_SOURCE_DIR}/elibs/mapmap/mapmap
+    ${CMAKE_SOURCE_DIR}/elibs/mapmap/ext/dset
 )
 
 include_directories(


### PR DESCRIPTION
A recent update in the mapmap_cpu dependency has added an external header to include. This PR just adds a reference to the header directory to allow successful builds.